### PR TITLE
[17.0][FIX] ensure partner context in price computation.

### DIFF
--- a/product_supplierinfo_for_customer/__manifest__.py
+++ b/product_supplierinfo_for_customer/__manifest__.py
@@ -13,7 +13,7 @@
     "category": "Sales Management",
     "license": "AGPL-3",
     "maintainers": ["luisg123v"],
-    "depends": ["product"],
+    "depends": ["sale"],
     "data": [
         "security/ir.model.access.csv",
         "views/product_views.xml",

--- a/product_supplierinfo_for_customer/models/__init__.py
+++ b/product_supplierinfo_for_customer/models/__init__.py
@@ -4,3 +4,4 @@ from . import product_supplierinfo
 from . import product_product
 from . import product_template
 from . import res_partner
+from . import sale_order_line

--- a/product_supplierinfo_for_customer/models/sale_order_line.py
+++ b/product_supplierinfo_for_customer/models/sale_order_line.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _get_product_price_context(self):
+        """Extend to make sure the partner context is set for price computation."""
+        self.ensure_one()
+        context = super()._get_product_price_context()
+        # Add partner_id to the context
+        if self.order_id.partner_id:
+            context.update({"partner_id": self.order_id.partner_id.id})
+        return context

--- a/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
+++ b/product_supplierinfo_for_customer/tests/test_product_supplierinfo_for_customer.py
@@ -17,6 +17,8 @@ class TestProductSupplierinfoForCustomer(TransactionCase):
         cls.customerinfo_model = cls.env["product.customerinfo"]
         cls.pricelist_item_model = cls.env["product.pricelist.item"]
         cls.pricelist_model = cls.env["product.pricelist"]
+        cls.sale_order_model = cls.env["sale.order"]
+        cls.sale_order_line_model = cls.env["sale.order.line"]
         cls.customer = cls._create_customer("customer1")
         cls.unknown = cls._create_customer("customer2")
         cls.product = cls.env.ref("product.product_product_4")
@@ -36,6 +38,27 @@ class TestProductSupplierinfoForCustomer(TransactionCase):
                 "compute_price": "fixed",
                 "fixed_price": 100.0,
                 "product_tmpl_id": cls.product.product_tmpl_id.id,
+            }
+        )
+        cls.pricelist_customer = cls.pricelist_model.create(
+            {
+                "name": "Test Pricelist Customer",
+                "currency_id": cls.env.ref("base.USD").id,
+            }
+        )
+        cls.pricelist_item_customer = cls.pricelist_item_model.create(
+            {
+                "applied_on": "3_global",
+                "base": "partner",
+                "name": "Test Pricelist Item",
+                "pricelist_id": cls.pricelist_customer.id,
+                "compute_price": "formula",
+            }
+        )
+        cls.sale_order_1 = cls.sale_order_model.create(
+            {
+                "partner_id": cls.customer.id,
+                "pricelist_id": cls.pricelist_customer.id,
             }
         )
 
@@ -185,3 +208,37 @@ class TestProductSupplierinfoForCustomer(TransactionCase):
             "partner", product_1.uom_id, self.company.currency_id, self.company
         )
         self.assertEqual(res[product_1.id], 10.0)
+
+    def test_product_supplierinfo_price_with_context_passed(self):
+        """Test normal behaviour when context is passed from view."""
+        # GIVEN / WHEN
+        self.sale_order_line_w_ctx = self.sale_order_line_model.with_context(
+            partner_id=self.customer.id
+        ).create(
+            {
+                "order_id": self.sale_order_1.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        # THEN
+        self.assertEqual(self.sale_order_line_w_ctx.price_unit, 100.0)
+
+    def test_product_supplierinfo_price_without_context_passed(self):
+        """Test case when context is not passed during price computation.
+
+        The context should be created in the method _get_product_price_context.
+        """
+        # GIVEN / WHEN
+        self.sale_order_line_wo_ctx = self.sale_order_line_model.create(
+            {
+                "order_id": self.sale_order_1.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        # THEN
+        self.assertEqual(
+            self.sale_order_line_wo_ctx.price_unit,
+            100.0,
+        )


### PR DESCRIPTION
partner context passed from view not always present.
task id - 25458

**Description**
In case of Pricelist type `partner`,  `price_unit` of sale order line is calculated using partner context passed in the view (https://github.com/odoo/odoo/blob/17.0/addons/sale/views/sale_order_views.xml#L520-L526).
However context is lost if price computation is triggered again from backend (e.g. when updating quantities) and it sets li`st price`, but not `product.customerinfo` price.

**Current Behaviour**
When pricelist type is "Partner Prices on the product form", unit price in sale order line sometimes is set from list price not from customer info. Example by updating product quantity a few times in sale order line.

**Expected Behavior**
When pricelist type is "Partner Prices on the product form", unit price in sale order line is always set from customer info.

**Proposed implementation**
extend `_get_product_price_context` and update context by adding `partner_id` from sale order.

