### PR TITLE
[17.0][FIX] product_secondary_unit: unnecessary sec_uom_qty set.

### DIFF
--- a/product_secondary_unit/models/product_secondary_unit_mixin.py
+++ b/product_secondary_unit/models/product_secondary_unit_mixin.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
-from odoo.tools.float_utils import float_round
+from odoo.tools.float_utils import float_is_zero, float_round
 
 
 class ProductSecondaryUnitMixin(models.AbstractModel):
@@ -76,7 +76,11 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
     def _compute_secondary_uom_qty(self):
         for line in self:
             if not line.secondary_uom_id:
-                line.secondary_uom_qty = 0.0
+                if not float_is_zero(
+                    line.secondary_uom_qty, precision_digits=line._get_uom_precision()
+                ):
+                    # Only set to 0.0 if it's not already 0.0
+                    self.secondary_uom_qty = 0.0
                 continue
             elif line.secondary_uom_id.dependency_type == "independent":
                 continue
@@ -87,6 +91,9 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
                 precision_rounding=line.secondary_uom_id.uom_id.rounding,
             )
             line.secondary_uom_qty = qty
+
+    def _get_uom_precision(self):
+        return self.env["decimal.precision"].precision_get("Product Unit of Measure")
 
     def _get_default_value_for_qty_field(self):
         return self.default_get([self._secondary_unit_fields["qty_field"]]).get(
@@ -126,7 +133,11 @@ class ProductSecondaryUnitMixin(models.AbstractModel):
         target model.
         """
         if not self.secondary_uom_id:
-            self.secondary_uom_qty = 0.0
+            if not float_is_zero(
+                self.secondary_uom_qty, precision_digits=self._get_uom_precision()
+            ):
+                # Only set to 0.0 if it's not already 0.0
+                self.secondary_uom_qty = 0.0
             return
         elif self.secondary_uom_id.dependency_type == "independent":
             return

--- a/product_secondary_unit/tests/test_secondary_unit_mixin.py
+++ b/product_secondary_unit/tests/test_secondary_unit_mixin.py
@@ -102,6 +102,23 @@ class TestProductSecondaryUnitMixin(TransactionCase, FakeModelLoader):
         fake_model._onchange_helper_product_uom_for_secondary()
         self.assertEqual(fake_model.secondary_uom_qty, 0)
 
+    def test_product_secondary_unit_mixin_remove_sec_uom(self):
+        fake_model = self.secondary_unit_fake
+        fake_model.write(
+            {"secondary_uom_qty": 5, "secondary_uom_id": self.secondary_unit_box_5.id}
+        )
+        fake_model.secondary_uom_id = False
+        self.assertEqual(fake_model.product_uom_qty, 0)
+        self.assertFalse(fake_model.secondary_uom_id)
+        self.assertEqual(fake_model.secondary_uom_qty, 0)
+
+    def test_product_secondary_unit_mixin_wo_sec_uom(self):
+        fake_model = self.secondary_unit_fake
+        fake_model.write({"product_uom_qty": 5})
+        self.assertEqual(fake_model.product_uom_qty, 5)
+        self.assertFalse(fake_model.secondary_uom_id)
+        self.assertEqual(fake_model.secondary_uom_qty, 0)
+
     def test_chained_compute_field(self):
         """Secondary_uom_qty has not been computed when secondary_uom_id changes"""
         fake_model = self.secondary_unit_fake


### PR DESCRIPTION
Setting sec uom qty, triggers unnecessary calculation on lines, where sec uom id is not set (used).
task id - 25342

**Description**
Problem noticed with `sale_order_secondary_unit` module, `sale.order.line`  which inherits `product_secondary_unit_mixin`. 
By creating sale order line from backend (not using UI, using connection) without `secondary_uom_id` and setting custom `price_unit` results wrong `price_subtotal` - not using custom `price_unit`, but using price from pricelist.

**Current Behaviour**
Run simple test on sale_order_secondary_unit module:
```python
class TestSaleOrderLine(TransactionCase):
    @classmethod
    def setUpClass(cls):
        super().setUpClass()
        cls.SaleOrder = cls.env["sale.order"]
        cls.SaleOrderLine = cls.env["sale.order.line"]
        cls.ProductProduct = cls.env["product.product"]
        cls.partner_1 = cls.env.ref("base.res_partner_1")
        cls.product_1 = cls.ProductProduct.create(
            {
                "name": "test",
                "lst_price": 13.00,
            }
        )

    def test_01_sale_order_create_custom_price_subtotal_wo_sec_unit(self):
        # GIVEN
        order_vals = {
            "partner_id": self.partner_1.id,
            "order_line": [
                Command.create(
                    {
                        "product_id": self.product_1.id,
                        "product_uom_qty": 1,
                        "price_unit": 2000.00,
                    }
                )
            ],
        }
        # WHEN
        self.order = self.SaleOrder.create(order_vals)
        # THEN
        self.order_lines = self.SaleOrderLine.search([("order_id", "=", self.order.id)])
        self.assertEqual(self.order_lines.price_unit, 2000.00)
        self.assertEqual(self.order_lines.price_subtotal, 2000.00)
        self.assertFalse(self.order_lines.secondary_uom_id)
        self.assertFalse(self.order_lines.secondary_uom_qty)
``` 
Test fails:
```python
 test_01_sale_order_create_custom_price_subtotal_wo_sec_unit
odoo-1  |     self.assertEqual(self.order_lines.price_subtotal, 2000.00)
odoo-1  | AssertionError: 13.0 != 2000.0

``` 


**Expected Behavior**
Test does not fail. Possible to set custom price unit with correct subtotal.

**Proposed implementation**
Remove unnecessary trigger: Set secondary_uom_qty when secondary_uom_id is not set, only if it is not 0. 

